### PR TITLE
Fix workflow permissions for PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     


### PR DESCRIPTION
## Summary
- Fixed critical GitHub Actions workflow permission issue
- Changed `pull-requests` permission from `read` to `write` to enable comment posting

## Problem
The Claude Code review workflow was unable to post comments on pull requests due to insufficient permissions. The workflow had `pull-requests: read` but needed `pull-requests: write` to post review comments.

## Solution
Updated `.github/workflows/claude-code-review.yml` line 24 to grant write permissions for pull requests.

## Test Plan
- [ ] Verify workflow can now post comments on PRs
- [ ] Confirm no other permissions were inadvertently changed
- [ ] Test that the workflow still runs successfully

🤖 Generated with [Claude Code](https://claude.ai/code)