### PR TITLE
fix: Replace hard-coded source quality with actual metadata

### DIFF
--- a/public/js/services/MetadataService.js
+++ b/public/js/services/MetadataService.js
@@ -102,11 +102,16 @@ export class MetadataService {
     }
 
     // Update quality information if available
+    // Handle both metadata.quality object format and direct bit_depth/sample_rate fields
     if (metadata.quality) {
       this.appState.setBatch({
         'quality.source': metadata.quality.source || this.appState.get('quality.source'),
         'quality.stream': metadata.quality.stream || this.appState.get('quality.stream')
       });
+    } else if (metadata.bit_depth && metadata.sample_rate) {
+      // Handle metadatav2.json format with bit_depth and sample_rate
+      const khz = (metadata.sample_rate / 1000).toFixed(1);
+      this.appState.set('quality.source', `${metadata.bit_depth}-bit ${khz}kHz`);
     }
   }
 

--- a/public/js/utils/AppState.js
+++ b/public/js/utils/AppState.js
@@ -20,7 +20,7 @@ export class AppState {
         status: 'Ready to play'
       },
       quality: {
-        source: '16-bit 44.1kHz',
+        source: 'Loading...',
         stream: '48kHz FLAC / HLS Lossless'
       },
       rating: {

--- a/public/radio-modular.html
+++ b/public/radio-modular.html
@@ -65,7 +65,7 @@
 
             <!-- Quality Information -->
             <div class="quality-info" role="region" aria-label="Audio quality information">
-                <p class="quality-title">Source quality: <span id="sourceQuality">16-bit 44.1kHz</span></p>
+                <p class="quality-title">Source quality: <span id="sourceQuality">Loading...</span></p>
                 <p class="quality-details">Stream quality: <span id="streamQuality">48kHz FLAC / HLS Lossless</span></p>
             </div>
 

--- a/public/radio.html
+++ b/public/radio.html
@@ -602,7 +602,7 @@
             </div>
 
             <div class="quality-info">
-                <p class="quality-title">Source quality: <span id="sourceQuality">16-bit 44.1kHz</span></p>
+                <p class="quality-title">Source quality: <span id="sourceQuality">Loading...</span></p>
                 <p class="quality-details">Stream quality: <span id="streamQuality">48kHz FLAC / HLS Lossless</span></p>
             </div>
 


### PR DESCRIPTION
- Changed default source quality from '16-bit 44.1kHz' to 'Loading...'
- Updated MetadataService to handle both metadata formats (quality object and bit_depth/sample_rate fields)
- Modified radio.html and radio-modular.html to show loading state initially
- AppState now shows 'Loading...' until actual metadata is received

Fixes #3